### PR TITLE
Status effect tweaks

### DIFF
--- a/code/modules/surgery/organs/vocal_cords.dm
+++ b/code/modules/surgery/organs/vocal_cords.dm
@@ -1255,7 +1255,7 @@
 								E.customTriggers[trigger] = list(trigger2, trigger3)
 								log_reagent("FERMICHEM: [H] has been implanted by [user] with [trigger], triggering [trigger2], to send [trigger3].")
 								if(findtext(trigger3, "admin"))
-									message_admins("FERMICHEM: [user] maybe be trying to abuse MKUltra by implanting by [H] with [trigger], triggering [trigger2], to send [trigger3].")
+									message_admins("FERMICHEM: [user] maybe be trying to abuse Enthrallment by implanting by [H] with [trigger], triggering [trigger2], to send [trigger3].")
 							else
 								E.customTriggers[trigger] = trigger2
 								log_reagent("FERMICHEM: [H] has been implanted by [user] with [trigger], triggering [trigger2].")
@@ -1323,7 +1323,7 @@
 						//objective = replacetext(lowertext(objective), "strangle", "meow at")
 						objective = replacetext(lowertext(objective), "suicide", "self-love")
 						message_admins("[H] has been implanted by [user] with the objective [objective].")
-						log_reagent("FERMICHEM: [H] has been implanted by [user] with the objective [objective] via MKUltra.")
+						log_reagent("FERMICHEM: [H] has been implanted by [user] with the objective [objective] via Enthrallment.")
 						addtimer(CALLBACK(GLOBAL_PROC, .proc/to_chat, H, "<span class='notice'>[(E.lewd?"Your [E.enthrallTitle]":"[E.master]")] whispers you a new objective.</span>"), 5)
 						brainwash(H, objective)
 						E.mental_capacity -= 200
@@ -1342,7 +1342,7 @@
 				var/instill = stripped_input(user, "Instill an emotion in [H].", MAX_MESSAGE_LEN)
 				to_chat(H, "<i>[instill]</i>")
 				to_chat(user, "<span class='notice'><i>You sucessfully instill a feeling in [H]</i></span>")
-				log_reagent("FERMICHEM: [H] has been instilled by [user] with [instill] via MKUltra.")
+				log_reagent("FERMICHEM: [H] has been instilled by [user] with [instill] via Enthrallment.")
 				E.cooldown += 1
 
 	//RECOGNISE

--- a/modular_citadel/code/datums/status_effects/chems.dm
+++ b/modular_citadel/code/datums/status_effects/chems.dm
@@ -148,6 +148,19 @@
 ///////////////////////////////////////////
 */
 
+/*/////////////////////////////////////////
+	The Big Enthrall Rework
+	We want enthrall to be independant of MKUltra.
+	This means that MKUltra will grant enthrall when consumed,
+	and will update the enthrall variables as before.
+
+	This might mean we'd want to make enthrall
+	datum/status_effect/<something else?>/enthrall
+	rather than
+	datum/status_effect/chem/enthrall
+	as it's no longer directly tied to a chem.
+*/
+
 //Preamble
 
 /mob/living/verb/toggle_hypno()
@@ -166,6 +179,7 @@
 	var/deltaResist //The total resistance added per resist click
 
 	var/phase = 1 //-1: resisted state, due to be removed.0: sleeper agent, no effects unless triggered 1: initial, 2: 2nd stage - more commands, 3rd: fully enthralled, 4th Mindbroken
+	var/phaselimit = 4 //the maximum allowed phase of the effect. By default, all phases are available, but it may depend on the source.
 
 	var/status = null //status effects
 	var/statusStrength = 0 //strength of status effect

--- a/modular_citadel/code/datums/status_effects/chems.dm
+++ b/modular_citadel/code/datums/status_effects/chems.dm
@@ -159,6 +159,7 @@
 	rather than
 	datum/status_effect/chem/enthrall
 	as it's no longer directly tied to a chem.
+////////////////////////////////////////////
 */
 
 //Preamble
@@ -168,7 +169,7 @@
 	set name = "Toggle Lewd Hypno"
 	set desc = "Allows you to toggle if you'd like lewd flavour messages for hypno features, such as MKUltra."
 	client.prefs.cit_toggles ^= HYPNO
-	to_chat(usr, "You [((client.prefs.cit_toggles & HYPNO) ?"will":"no longer")] receive lewd flavour messages for hypno.")
+	to_chat(usr, "You [((client.prefs.cit_toggles & HYPNO) ?"will":"will no longer")] receive lewd flavour messages for hypno.")
 
 /datum/status_effect/chem/enthrall
 	id = "enthrall"
@@ -212,6 +213,7 @@
 
 /datum/status_effect/chem/enthrall/on_apply()
 	var/mob/living/carbon/M = owner
+	//We're gonna make a proc that defines the owner and such
 	var/datum/reagent/fermi/enthrall/E = locate(/datum/reagent/fermi/enthrall) in M.reagents.reagent_list
 	if(!E)
 		message_admins("WARNING: FermiChem: No master found in thrall, did you bus in the status? You need to set up the vars manually in the chem if it's not reacted/bussed. Someone set up the reaction/status proc incorrectly if not (Don't use donor blood). Console them with a chemcat plush maybe?")
@@ -561,6 +563,22 @@
 	to_chat(owner, "<span class='big redtext'><i>You're now free of [master]'s influence, and fully independent!'</i></span>")
 	UnregisterSignal(owner, COMSIG_GLOB_LIVING_SAY_SPECIAL)
 	return ..()
+
+/datum/status_effect/chem/enthrall/proc/setup_vars(masterID, masterTitle, maxPhase)
+	//this proc just sets up the big important variables, and is how the master is set up
+	//It should ALWAYS BE CALLED when adding enthrall, or else you'll run into Fun Issues(tm)
+	enthrallID = masterID
+	enthrallTitle = masterTitle
+	if (!isnum(maxPhase))
+		return
+	switch (maxPhase)
+		if (0 to 4)
+			phaselimit = maxPhase
+		if (5 to INFINITY)
+			log_reagent("WARNING: FERMICHEM: ENTHRALL: Failed to setup values for status on [owner] ckey: [owner.key]! Maximum phase greater than 4.")
+	master = get_mob_by_key(enthrallID)
+	log_reagent("FERMICHEM: ENTHRALL: Status applied on [owner] ckey: [owner.key] with a master of [master] ckey: [enthrallID], and maximum phase of [phaselimit].")
+	return
 
 /datum/status_effect/chem/enthrall/proc/owner_hear(datum/source, list/hearing_args)
 	if(lewd == FALSE)

--- a/modular_citadel/code/datums/status_effects/chems.dm
+++ b/modular_citadel/code/datums/status_effects/chems.dm
@@ -192,6 +192,7 @@
 
 	var/initialSetup = FALSE //has the status effect been set up and logged
 	var/isExposed = FALSE //Registers whether or not the player is actually exposed to the thing that's causing their enthrallment (MKUltra in bloodstream, hypnotic eyes, etc.)
+	var/list/enthrallSources = list() //List of all enthrall sources.
 
 	var/mental_capacity //Higher it is, lower the cooldown on commands, capacity reduces with resistance.
 
@@ -217,6 +218,11 @@
 /datum/status_effect/chem/enthrall/on_apply()
 	var/mob/living/carbon/M = owner
 	//We're gonna make a proc that defines the master and such
+	//be ready to delete the next three lines and remove the args if they cause problems
+	//enthrallID = masterID
+	//enthrallTitle = masterTitle
+	//phaselimit = maxPhase
+
 	subjectTerm = M.client?.prefs.custom_names["subject"]
 	//if(M.ckey == enthrallID)
 	//	owner.remove_status_effect(src)//At the moment, a user can enthrall themselves, toggle this back in if that should be removed.
@@ -241,7 +247,7 @@
 	if(phase > phaselimit)
 		phase = phaselimit //just make sure we don't surpass the phase limit.
 	//breaking free
-	if(!isExposed)
+	if(!enthrallSources.length())
 		if (phase < 3 && phase != 0)
 			deltaResist += 3//If you're not exposed, then you break out quickly
 			if(prob(5))

--- a/modular_citadel/code/datums/status_effects/chems.dm
+++ b/modular_citadel/code/datums/status_effects/chems.dm
@@ -235,7 +235,7 @@
 		var/message = "[(lewd ? "I am a good [subjectTerm] for [enthrallTitle]." : "[master] always knows just what to say.")]"
 		SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "enthrall", /datum/mood_event/enthrall, message)
 		to_chat(owner, "<span class='[(lewd ?"big velvet":"big warning")]'><b>You feel inexplicably drawn towards [master], their words having a demonstrable effect on you. It seems the closer you are to them, the stronger the effect is. However you aren't fully swayed yet and can fight against their effects by resisting repeatedly!</b></span>")
-		log_reagent("FERMICHEM: MKULTRA: Status applied on [owner] ckey: [owner.key] with a master of [master] ckey: [enthrallID].")
+		log_reagent("FERMICHEM: Enthrallment: Status applied on [owner] ckey: [owner.key] with a master of [master] ckey: [enthrallID].")
 		SSblackbox.record_feedback("tally", "fermi_chem", 1, "Enthrall attempts")
 		initialSetup = TRUE
 	if(phase > phaselimit)
@@ -266,7 +266,7 @@
 	switch(phase)
 		if(-1)//fully removed
 			SEND_SIGNAL(M, COMSIG_CLEAR_MOOD_EVENT, "enthrall")
-			log_reagent("FERMICHEM: MKULTRA: Status REMOVED from [owner] ckey: [owner.key] with a master of [master] ckey: [enthrallID].")
+			log_reagent("FERMICHEM: Enthrallment: Status REMOVED from [owner] ckey: [owner.key] with a master of [master] ckey: [enthrallID].")
 			owner.remove_status_effect(src)
 			return
 		if(0)// sleeper agent
@@ -307,7 +307,7 @@
 				else
 					to_chat(owner, "<span class='big nicegreen'><i>You are unable to put up a resistance any longer, and are now [master]'s faithful follower. In your loyal state you cannot stand the thought of being permanently separated from your [enthrallTitle] - the idea of becoming violent or committing suicide, even if ordered to, is unthinkable.</i></span>")
 				to_chat(master, "<span class='notice'><i>Your [(lewd? "[subjectTerm]":"follower")] [owner] appears to have fully fallen under your sway.</i></span>")
-				log_reagent("FERMICHEM: MKULTRA: Status on [owner] ckey: [owner.key] has been fully enthralled (state 3) with a master of [master] ckey: [enthrallID].")
+				log_reagent("FERMICHEM: Enthrallment: Status on [owner] ckey: [owner.key] has been fully enthralled (state 3) with a master of [master] ckey: [enthrallID].")
 				SSblackbox.record_feedback("tally", "fermi_chem", 1, "thralls fully enthralled.")
 			else if (resistanceTally > 200)
 				enthrallTally *= 0.5
@@ -324,7 +324,7 @@
 				resistanceTally = 0
 				resistGrowth = 0
 				to_chat(owner, "<span class='notice'><i>The separation from [(lewd?"your [enthrallTitle]":"[master]")] sparks a small flame of resistance in yourself, as your mind slowly starts to return to normal.</i></span>")
-				REMOVE_TRAIT(owner, TRAIT_PACIFISM, "MKUltra")
+				REMOVE_TRAIT(owner, TRAIT_PACIFISM, "Enthrallment")
 			if(lewd && prob(1) && !customEcho)
 				to_chat(owner, "<span class='love'><i>[pick("I belong to [enthrallTitle].", "I obey [enthrallTitle].","[enthrallTitle] knows what's best for me.", "Obedence is pleasure.",  "I exist to serve [enthrallTitle].", "[enthrallTitle] is so dominant, it feels right to obey them.","I am [enthrallTitle]'s loyal [subjectTerm]")].</i></span>")
 		if (4) //mindbroken
@@ -373,7 +373,7 @@
 			if(owner.getOrganLoss(ORGAN_SLOT_BRAIN) >=20)
 				owner.adjustOrganLoss(ORGAN_SLOT_BRAIN, -0.2)
 			if(withdrawal == TRUE)
-				REMOVE_TRAIT(owner, TRAIT_PACIFISM, "MKUltra")
+				REMOVE_TRAIT(owner, TRAIT_PACIFISM, "Enthrallment")
 				SEND_SIGNAL(M, COMSIG_CLEAR_MOOD_EVENT, "EnthMissing1")
 				SEND_SIGNAL(M, COMSIG_CLEAR_MOOD_EVENT, "EnthMissing2")
 				SEND_SIGNAL(M, COMSIG_CLEAR_MOOD_EVENT, "EnthMissing3")
@@ -387,7 +387,7 @@
 		switch(withdrawalTick)//denial
 			if(5)//To reduce spam
 				to_chat(owner, "<span class='big warning'><b>You are unable to complete [(lewd?"your [enthrallTitle]":"[master]")]'s orders without their presence, and any commands and objectives previously given to you are not in effect until you are reunited.</b></span>")
-				ADD_TRAIT(owner, TRAIT_PACIFISM, "MKUltra") //IMPORTANT
+				ADD_TRAIT(owner, TRAIT_PACIFISM, "Enthrallment") //IMPORTANT
 			if(10 to 35)//Gives wiggle room, so you're not SUPER needy
 				if(prob(5))
 					to_chat(owner, "<span class='notice'><i>You're starting to miss [(lewd?"your [enthrallTitle]":"[master]")].</i></span>")
@@ -516,7 +516,7 @@
 				cooldown += 1 //Cooldown doesn't process till status is done
 
 		else if (status == "pacify")
-			ADD_TRAIT(owner, TRAIT_PACIFISM, "MKUltraStatus")
+			ADD_TRAIT(owner, TRAIT_PACIFISM, "EnthrallmentStatus")
 			status = null
 
 			//Truth serum?
@@ -566,7 +566,7 @@
 	SEND_SIGNAL(M, COMSIG_CLEAR_MOOD_EVENT, "EnthMissing4")
 	UnregisterSignal(M, COMSIG_LIVING_RESIST)
 	UnregisterSignal(owner, COMSIG_MOVABLE_HEAR)
-	REMOVE_TRAIT(owner, TRAIT_PACIFISM, "MKUltra")
+	REMOVE_TRAIT(owner, TRAIT_PACIFISM, "Enthrallment")
 	to_chat(owner, "<span class='big redtext'><i>You're now free of [master]'s influence, and fully independent!'</i></span>")
 	UnregisterSignal(owner, COMSIG_GLOB_LIVING_SAY_SPECIAL)
 	return ..()
@@ -598,14 +598,14 @@
 		var/cached_trigger = lowertext(trigger)
 		if (findtext(raw_message, cached_trigger))//if trigger1 is the message
 			cTriggered = 5 //Stops triggerparties and as a result, stops servercrashes.
-			log_reagent("FERMICHEM: MKULTRA: [owner] ckey: [owner.key] has been triggered with [cached_trigger] from [hearing_args[HEARING_SPEAKER]] saying: \"[hearing_args[HEARING_MESSAGE]]\". (their master being [master] ckey: [enthrallID].)")
+			log_reagent("FERMICHEM: Enthrallment: [owner] ckey: [owner.key] has been triggered with [cached_trigger] from [hearing_args[HEARING_SPEAKER]] saying: \"[hearing_args[HEARING_MESSAGE]]\". (their master being [master] ckey: [enthrallID].)")
 
 			//Speak (Forces player to talk)
 			if (lowertext(customTriggers[trigger][1]) == "speak")//trigger2
 				var/saytext = "Your mouth moves on it's own before you can even catch it."
 				addtimer(CALLBACK(GLOBAL_PROC, .proc/to_chat, C, "<span class='notice'><i>[saytext]</i></span>"), 5)
 				addtimer(CALLBACK(C, /atom/movable/proc/say, "[customTriggers[trigger][2]]"), 5)
-				log_reagent("FERMICHEM: MKULTRA: [owner] ckey: [owner.key] has been forced to say: \"[customTriggers[trigger][2]]\" from previous trigger.")
+				log_reagent("FERMICHEM: Enthrallment: [owner] ckey: [owner.key] has been forced to say: \"[customTriggers[trigger][2]]\" from previous trigger.")
 
 
 			//Echo (repeats message!) allows customisation, but won't display var calls! Defaults to hypnophrase.
@@ -653,7 +653,7 @@
 				var/mob/living/carbon/human/o = owner
 				o.apply_status_effect(/datum/status_effect/trance, 200, TRUE)
 				tranceTime = 50
-				log_reagent("FERMICHEM: MKULTRA: [owner] ckey: [owner.key] has been tranced from previous trigger.")
+				log_reagent("FERMICHEM: Enthrallment: [owner] ckey: [owner.key] has been tranced from previous trigger.")
 
 	return
 

--- a/modular_citadel/code/modules/reagents/chemistry/reagents/MKUltra.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/reagents/MKUltra.dm
@@ -185,11 +185,11 @@ Creating a chem with a low purity will make you permanently fall in love with so
 		qdel(Vc)
 		to_chat(M, "<span class='notice'><i>You feel your vocal chords tingle as you speak in a more charasmatic and enthralling tone.</i></span>")
 	else
-		log_reagent("FERMICHEM: MKUltra: [creatorName], [creatorID], is enthralling [M.name], [M.ckey]")
 		var/datum/status_effect/chem/enthrall/H
 		M.apply_status_effect(H)
-		H.setup_vars(creatorID, creatorTitle, 4)
+		H.setup_vars(creatorID, creatorTitle, 4)H.setup_vars(creatorID, creatorTitle, 4)
 		H.isExposed = TRUE
+		log_reagent("FERMICHEM: MKUltra: [creatorName], [creatorID], is enthralling [M.name], [M.ckey]")
 	log_reagent("FERMICHEM: [M] ckey: [M.key] has taken MKUltra")
 
 /datum/reagent/fermi/enthrall/on_mob_life(mob/living/carbon/M)
@@ -242,7 +242,7 @@ Creating a chem with a low purity will make you permanently fall in love with so
 	if (M.ckey == creatorID && creatorName == M.real_name)//If the creator drinks 100u, then you get the status for someone random (They don't have the vocal chords though, so it's limited.)
 		if (!M.has_status_effect(/datum/status_effect/chem/enthrall))
 			to_chat(M, "<span class='love'><i>You are unable to resist your own charms anymore, and become a full blown narcissist.</i></span>")
-	ADD_TRAIT(M, TRAIT_PACIFISM, "MKUltra")
+	ADD_TRAIT(M, TRAIT_PACIFISM, "Enthrallment")
 	var/datum/status_effect/chem/enthrall/E
 	if (!M.has_status_effect(/datum/status_effect/chem/enthrall))
 		M.apply_status_effect(/datum/status_effect/chem/enthrall)

--- a/modular_citadel/code/modules/reagents/chemistry/reagents/MKUltra.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/reagents/MKUltra.dm
@@ -187,7 +187,7 @@ Creating a chem with a low purity will make you permanently fall in love with so
 	else
 		var/datum/status_effect/chem/enthrall/H
 		M.apply_status_effect(H)
-		H.setup_vars(creatorID, creatorTitle, 4)H.setup_vars(creatorID, creatorTitle, 4)
+		H.setup_vars(creatorID, creatorTitle, 4)
 		H.isExposed = TRUE
 		log_reagent("FERMICHEM: MKUltra: [creatorName], [creatorID], is enthralling [M.name], [M.ckey]")
 	log_reagent("FERMICHEM: [M] ckey: [M.key] has taken MKUltra")

--- a/modular_citadel/code/modules/reagents/chemistry/reagents/MKUltra.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/reagents/MKUltra.dm
@@ -188,7 +188,7 @@ Creating a chem with a low purity will make you permanently fall in love with so
 		var/datum/status_effect/chem/enthrall/H
 		M.apply_status_effect(H)
 		H.setup_vars(creatorID, creatorTitle, 4)
-		H.isExposed = TRUE
+		H.enthrallSources += src
 		log_reagent("FERMICHEM: MKUltra: [creatorName], [creatorID], is enthralling [M.name], [M.ckey]")
 	log_reagent("FERMICHEM: [M] ckey: [M.key] has taken MKUltra")
 
@@ -271,7 +271,7 @@ Creating a chem with a low purity will make you permanently fall in love with so
 /datum/reagent/fermi/enthrall/on_mob_delete(mob/living/carbon/M)
 	. = ..()
 	E = M.has_status_effect(/datum/status_effect/chem/enthrall)
-	E.isExposed = FALSE
+	E.enthrallSources -= src
 	return
 
 //Creates a gas cloud when the reaction blows up, causing everyone in it to fall in love with someone/something while it's in their system.

--- a/modular_citadel/code/modules/reagents/chemistry/reagents/MKUltra.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/reagents/MKUltra.dm
@@ -186,7 +186,10 @@ Creating a chem with a low purity will make you permanently fall in love with so
 		to_chat(M, "<span class='notice'><i>You feel your vocal chords tingle as you speak in a more charasmatic and enthralling tone.</i></span>")
 	else
 		log_reagent("FERMICHEM: MKUltra: [creatorName], [creatorID], is enthralling [M.name], [M.ckey]")
-		M.apply_status_effect(/datum/status_effect/chem/enthrall)
+		var/datum/status_effect/chem/enthrall/H
+		M.apply_status_effect(H)
+		H.setup_vars(creatorID, creatorTitle, 4)
+		H.isExposed = TRUE
 	log_reagent("FERMICHEM: [M] ckey: [M.key] has taken MKUltra")
 
 /datum/reagent/fermi/enthrall/on_mob_life(mob/living/carbon/M)
@@ -264,6 +267,12 @@ Creating a chem with a low purity will make you permanently fall in love with so
 /datum/reagent/fermi/enthrall/overdose_process(mob/living/carbon/M)
 	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.2)//should be ~30 in total
 	..()
+
+/datum/reagent/fermi/enthrall/on_mob_delete(mob/living/carbon/M)
+	. = ..()
+	E = M.has_status_effect(/datum/status_effect/chem/enthrall)
+	E.isExposed = FALSE
+	return
 
 //Creates a gas cloud when the reaction blows up, causing everyone in it to fall in love with someone/something while it's in their system.
 /datum/reagent/fermi/enthrallExplo//Created in a gas cloud when it explodes


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Decouples the enthrall status effect from MKUltra, the chem. MKUltra now grants enthrall, but other sources can grant enthrall as well. 
Important to note: adding enthrall requires you to set up some variables using .setup_vars (yes this is jank but it's for a reason) and add the source of the enthrallment to the .enthrallSources list of the status effect. The source should be removed from the list when it's no longer in effect (ie. MKUltra has left the system, no longer looking at hypnotic eyes, etc.)
You also may want to manually increase the effects enthrallTally value! MKUltra increases it by one on every on_mob_life. Velvet chords are still needed to cause most effects.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
This makes hypnosis stuff so much easier to add

## Changelog
:cl:
tweak: mkultra is now seperate from enthrall
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
