### PR TITLE
Hypno eyes

### DIFF
--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -201,9 +201,6 @@
 
 /datum/quirk/snakeeyes/on_spawn()
 	var/mob/living/carbon/human/H = quirk_holder
-	//var/obj/item/autosurgeon/snakeeyes/snakeeyes = new(get_turf(H))
-	//H.equip_to_slot(snakeeyes, SLOT_IN_BACKPACK)
-	//H.regenerate_icons()
 	if(!ishuman(H))
 		return
 	var/obj/item/organ/eyes/Vc = H.getorganslot(ORGAN_SLOT_EYES)

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -191,6 +191,28 @@
 	H.equip_to_slot(gloweyes, SLOT_IN_BACKPACK)
 	H.regenerate_icons()
 
+
+/datum/quirk/snakeeyes
+	name = "Hypnotic Eyes"
+	desc = "All it takes is a little flick of the switch in your brain, and anything making eye contact with you just falls into a sweet, blissful trance."
+	value = 1
+	gain_text = "<span class='notice'>You feel as though your gaze is quite... Hypnotic.</span>"
+	lose_text = "<span class='danger'>Your gaze suddenly feels a lot duller.</span>"
+
+/datum/quirk/snakeeyes/on_spawn()
+	var/mob/living/carbon/human/H = quirk_holder
+	//var/obj/item/autosurgeon/snakeeyes/snakeeyes = new(get_turf(H))
+	//H.equip_to_slot(snakeeyes, SLOT_IN_BACKPACK)
+	//H.regenerate_icons()
+	if(!ishuman(H))
+		return
+	var/obj/item/organ/eyes/Vc = H.getorganslot(ORGAN_SLOT_EYES)
+	var/obj/item/organ/eyes/nVc = new /obj/item/organ/eyes/snakeeyes
+	if(Vc)
+		Vc.Remove()
+	nVc.Insert(H)
+	qdel(Vc)
+
 /datum/quirk/bloodpressure
 	name = "Polycythemia vera"
 	desc = "You've a treated form of Polycythemia vera that increases the total blood volume inside of you as well as the rate of replenishment!"

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -394,6 +394,80 @@
 	name = "ipc eyes"
 	icon_state = "cybernetic_eyeballs"
 
+/obj/item/organ/eyes/snakeeyes
+	name = "hypnotic eyes"
+	desc = "These eyes appear to be capable of morphing into a pretty pattern, allowing the owner to entrance other sentient creatures by simply making eye contact."
+	actions_types = list(/datum/action/item_action/organ_action/toggle)
+	var/mutable_appearance/mob_overlay
+	var/has_spiral = FALSE
+
+/obj/item/organ/eyes/snakeeyes/Initialize()
+	. = ..()
+	mob_overlay = mutable_appearance('icons/mob/human_face.dmi', "eyes_glow_gs", ABOVE_LIGHTING_LAYER, ABOVE_LIGHTING_PLANE)
+
+/obj/item/organ/eyes/snakeeyes/Insert(mob/living/carbon/M, special, drop_if_replaced)
+	. = ..()
+	if(eye_color)
+		mob_overlay.color = "#[eye_color]"
+	if(!iscarbon(M))
+		return
+	var/obj/item/organ/vocal_cords/Vc = M.getorganslot(ORGAN_SLOT_VOICE)
+	var/obj/item/organ/vocal_cords/nVc = new /obj/item/organ/vocal_cords/velvet
+	if(Vc)
+		Vc.Remove()
+	nVc.Insert(M)
+	qdel(Vc)
+
+/obj/item/organ/eyes/snakeeyes/on_life()
+	. = ..()
+	if(!owner)
+		return
+	if((!. || eye_damaged) && has_spiral)
+		to_chat(owner, "<span class='warning'>The spiral in your [src] quickly fades away as you lose the ability to focus...</span>")
+		toggle_spiral(TRUE)
+		return
+	for(var/mob/living/carbon/M in view(3, owner))
+		if(get_cardinal_dir(owner, M) == owner.dir && turn(M.dir, 180) == owner.dir)
+			do_enthrallment(M)
+
+/obj/item/organ/eyes/snakeeyes/proc/do_enthrallment(mob/living/carbon/M)
+	if(!istype(M))
+		return
+	//Below is commented out in favor of debug text solely so I can test this before I start gutting parts of the enthrallment status.
+	//var/datum/status_effect/chem/enthrall/E = M.has_status_effect(/datum/status_effect/chem/enthrall)
+	//if(!E)
+		//E = M.apply_status_effect(/datum/status_effect/chem/enthrall)
+	to_chat(world, "[M] is getting enthralled")
+	
+
+/obj/item/organ/eyes/snakeeyes/proc/add_mob_overlay()
+	if(!QDELETED(owner))
+		mob_overlay.color = "#[eye_color]"
+		owner.add_overlay(mob_overlay)
+
+/obj/item/organ/eyes/snakeeyes/proc/remove_mob_overlay()
+	if(!QDELETED(owner))
+		owner.cut_overlay(mob_overlay)
+
+/obj/item/organ/eyes/snakeeyes/proc/toggle_spiral(silent)
+	if(!has_spiral)
+		if(!silent)
+			to_chat(owner, "<span class='notice'>You start gazing more intently with your [src]...</span>")
+		has_spiral = TRUE
+		add_mob_overlay()
+	else
+		if(!silent)
+			to_chat(owner, "<span class='notice'>You stop gazing intently with your [src].</span>")
+		has_spiral = FALSE
+		remove_mob_overlay()
+
+/obj/item/organ/eyes/snakeeyes/ui_action_click(owner, action)
+	if(istype(action, /datum/action/item_action/organ_action/toggle))
+		if(!eye_damaged)
+			toggle_spiral()
+		else
+			to_chat(owner, "<span class='warning'>Your [src] hurt too much to gaze intently.</span>")
+
 #undef BLURRY_VISION_ONE
 #undef BLURRY_VISION_TWO
 #undef BLIND_VISION_THREE

--- a/code/modules/surgery/organs/vocal_cords.dm
+++ b/code/modules/surgery/organs/vocal_cords.dm
@@ -1111,7 +1111,7 @@
 						var/newTerm = stripped_input(user, "Enter the new sub term", MAX_MESSAGE_LEN)
 						E.subjectTerm = newTerm
 						to_chat(user, "<span class='notice'><i>You successfully teach [H] their proper place.</i></span>")
-						to_chat(V, "<span class='notice'><i>You suddenly realize your proper place as [(E.lewd?"your [E.enthrallTitle]'s [E.subjectTerm]!":"[E.master]'s [E.subjectTerm]!"")
+						to_chat(V, "<span class='notice'><i>You suddenly realize your proper place as [(E.lewd?"your [E.enthrallTitle]'s [E.subjectTerm]!":"[E.master]'s [E.subjectTerm]!")]")
 
 	//awoo
 	else if((findtext(message, awoo_words)))

--- a/modular_citadel/code/datums/status_effects/chems.dm
+++ b/modular_citadel/code/datums/status_effects/chems.dm
@@ -247,7 +247,7 @@
 	if(phase > phaselimit)
 		phase = phaselimit //just make sure we don't surpass the phase limit.
 	//breaking free
-	if(!enthrallSources.length())
+	if(!enthrallSources.len)
 		if (phase < 3 && phase != 0)
 			deltaResist += 3//If you're not exposed, then you break out quickly
 			if(prob(5))
@@ -562,7 +562,7 @@
 //Remove all stuff
 /datum/status_effect/chem/enthrall/on_remove()
 	var/mob/living/carbon/M = owner
-	M.mind.remove_antag_datum(/datum/antagonist/brainwashed)
+	M.mind?.remove_antag_datum(/datum/antagonist/brainwashed)
 	SEND_SIGNAL(M, COMSIG_CLEAR_MOOD_EVENT, "enthrall")
 	SEND_SIGNAL(M, COMSIG_CLEAR_MOOD_EVENT, "enthrallpraise")
 	SEND_SIGNAL(M, COMSIG_CLEAR_MOOD_EVENT, "enthrallscold")

--- a/modular_citadel/code/modules/reagents/chemistry/reagents/MKUltra.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/reagents/MKUltra.dm
@@ -185,10 +185,9 @@ Creating a chem with a low purity will make you permanently fall in love with so
 		qdel(Vc)
 		to_chat(M, "<span class='notice'><i>You feel your vocal chords tingle as you speak in a more charasmatic and enthralling tone.</i></span>")
 	else
-		var/datum/status_effect/chem/enthrall/H
-		M.apply_status_effect(H)
+		var/datum/status_effect/chem/enthrall/H = M.apply_status_effect(/datum/status_effect/chem/enthrall)
 		H.setup_vars(creatorID, creatorTitle, 4)
-		H.enthrallSources += src
+		H.enthrallSources |= src
 		log_reagent("FERMICHEM: MKUltra: [creatorName], [creatorID], is enthralling [M.name], [M.ckey]")
 	log_reagent("FERMICHEM: [M] ckey: [M.key] has taken MKUltra")
 
@@ -269,10 +268,9 @@ Creating a chem with a low purity will make you permanently fall in love with so
 	..()
 
 /datum/reagent/fermi/enthrall/on_mob_delete(mob/living/carbon/M)
-	. = ..()
-	E = M.has_status_effect(/datum/status_effect/chem/enthrall)
+	var/datum/status_effect/chem/enthrall/E = M.has_status_effect(/datum/status_effect/chem/enthrall)
 	E.enthrallSources -= src
-	return
+	. = ..()
 
 //Creates a gas cloud when the reaction blows up, causing everyone in it to fall in love with someone/something while it's in their system.
 /datum/reagent/fermi/enthrallExplo//Created in a gas cloud when it explodes


### PR DESCRIPTION
## About The Pull Request

This PR adds hypnotic eyes to the game, available from the quirk menu for 1 point. When you make eye contact with spacemen while your hypnotic eyes are enabled, you'll begin enthralling the spaceman. Disabling your hypno eyes or breaking eye contact will remove the eyes from the spaceman's enthrallment sources, but won't delete the enthrallment entirely. Additionally, the eyes won't reset the enthrallment owner, but it will naturally accelerate any enthrallment that's already present.

## Changelog
:cl: Bhijn
add: Eyes that go @ w @ 
/:cl:
